### PR TITLE
Remove duplicate table creation in simulator

### DIFF
--- a/blackjack/simulator.py
+++ b/blackjack/simulator.py
@@ -104,10 +104,6 @@ class Simulator:
             """
         )
 
-        cur.execute("CREATE TABLE IF NOT EXISTS bankroll (trial INTEGER, hand INTEGER, bankroll REAL)")
-        cur.execute("CREATE TABLE IF NOT EXISTS summary (trial INTEGER, hands_played INTEGER, bankroll REAL)")
-        cur.execute("CREATE TABLE IF NOT EXISTS card_distribution (trial INTEGER, card TEXT, count INTEGER)")
-
         self.conn.commit()
 
     def _format_round(


### PR DESCRIPTION
## Summary
- Remove redundant `CREATE TABLE` statements for bankroll, summary, and card distribution
- Leave single set of permanent and temporary table initializations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b72c94866883318cb1232a28aab6ac