### PR TITLE
refactor: use relative imports

### DIFF
--- a/blackjack/__main__.py
+++ b/blackjack/__main__.py
@@ -1,20 +1,9 @@
-
-try:  # pragma: no cover - fallback for direct execution
-    from .gui import SimulatorGUI
-except ImportError:  # pragma: no cover
-    from gui import SimulatorGUI  # type: ignore
-
 import argparse
 from pathlib import Path
 
-try:  # pragma: no cover - fallback for direct execution
-    from .gui import SimulatorGUI
-    from .settings import SimulationSettings, DEFAULT_STRATEGY_FILE
-    from .simulator import Simulator
-except ImportError:  # pragma: no cover
-    from gui import SimulatorGUI  # type: ignore
-    from settings import SimulationSettings, DEFAULT_STRATEGY_FILE  # type: ignore
-    from simulator import Simulator  # type: ignore
+from .gui import SimulatorGUI
+from .settings import SimulationSettings, DEFAULT_STRATEGY_FILE
+from .simulator import Simulator
 
 
 def parse_args() -> tuple[SimulationSettings, bool]:

--- a/blackjack/dealer.py
+++ b/blackjack/dealer.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 from dataclasses import dataclass
-try:  # pragma: no cover - fallback for direct execution
-    from .cards import Shoe
-    from .hand import Hand
-except ImportError:  # pragma: no cover
-    from cards import Shoe  # type: ignore
-    from hand import Hand  # type: ignore
+
+from .cards import Shoe
+from .hand import Hand
 
 @dataclass
 class Dealer:

--- a/blackjack/gui.py
+++ b/blackjack/gui.py
@@ -4,12 +4,8 @@ from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 import pandas as pd
 
-try:  # pragma: no cover - fallback for direct execution
-    from .settings import SimulationSettings
-    from .simulator import Simulator
-except ImportError:  # pragma: no cover
-    from settings import SimulationSettings  # type: ignore
-    from simulator import Simulator  # type: ignore
+from .settings import SimulationSettings
+from .simulator import Simulator
 
 
 class SimulatorGUI:

--- a/blackjack/hand.py
+++ b/blackjack/hand.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List
-try:  # pragma: no cover - fallback for direct execution
-    from .cards import Card
-except ImportError:  # pragma: no cover
-    from cards import Card  # type: ignore
+
+from .cards import Card
 
 @dataclass
 class Hand:

--- a/blackjack/player.py
+++ b/blackjack/player.py
@@ -2,14 +2,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-try:  # pragma: no cover - fallback for direct execution
-    from .hand import Hand
-    from .cards import Shoe
-    from .strategy import BasicStrategy
-except ImportError:  # pragma: no cover
-    from hand import Hand  # type: ignore
-    from cards import Shoe  # type: ignore
-    from strategy import BasicStrategy  # type: ignore
+from .hand import Hand
+from .cards import Shoe
+from .strategy import BasicStrategy
 
 @dataclass
 class PlayerSettings:

--- a/blackjack/simulator.py
+++ b/blackjack/simulator.py
@@ -2,34 +2,14 @@ from __future__ import annotations
 import sqlite3
 import random
 from dataclasses import asdict
-from importlib import import_module
 from typing import List
 
-
-def _import(name: str):
-    """Import ``name`` relative to this package, falling back to absolute."""
-    try:
-        return import_module(f".{name}", __package__)
-    except ImportError:
-        return import_module(name)
-
-
-# Load modules with graceful fallback for standalone execution
-settings = _import("settings")
-cards = _import("cards")
-player = _import("player")
-dealer = _import("dealer")
-strategy = _import("strategy")
-hand = _import("hand")
-
-SimulationSettings = settings.SimulationSettings
-Shoe = cards.Shoe
-Player = player.Player
-PlayerSettings = player.PlayerSettings
-Dealer = dealer.Dealer
-BasicStrategy = strategy.BasicStrategy
-Hand = hand.Hand
-Card = cards.Card
+from .settings import SimulationSettings
+from .cards import Shoe, Card
+from .player import Player, PlayerSettings
+from .dealer import Dealer
+from .strategy import BasicStrategy
+from .hand import Hand
 
 
 class Simulator:

--- a/blackjack/strategy.py
+++ b/blackjack/strategy.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict
 import json
-try:  # pragma: no cover - fallback for direct execution
-    from .hand import Hand
-except ImportError:  # pragma: no cover
-    from hand import Hand  # type: ignore
+
+from .hand import Hand
 
 Action = str  # 'hit', 'stand', 'double', 'split', 'surrender'
 


### PR DESCRIPTION
## Summary
- remove try/except fallback imports in Blackjack package and use explicit relative imports
- consolidate `__main__` module imports into a single section

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b72e65b9108331aed87c988d1046f9